### PR TITLE
refactor: Claude Code 플러그인 표준 구조로 전환

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "slack-to-notion",
+  "version": "0.1.0",
+  "description": "Slack 메시지/스레드를 분석하여 Notion 페이지로 정리하는 Claude Code 플러그인",
+  "author": {
+    "name": "dykim-base-project"
+  },
+  "repository": "https://github.com/dykim-base-project/claude-slack-to-notion",
+  "mcpServers": "./.mcp.json"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "slack-to-notion": {
+      "command": "bash",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/run-server.sh"],
+      "env": {
+        "SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}",
+        "NOTION_API_KEY": "${NOTION_API_KEY}",
+        "NOTION_PARENT_PAGE_ID": "${NOTION_PARENT_PAGE_ID}"
+      }
+    }
+  }
+}

--- a/docs/dev-log/issue-15.md
+++ b/docs/dev-log/issue-15.md
@@ -1,0 +1,96 @@
+# Issue #15: Claude Code 플러그인 표준 구조로 전환
+
+## 메타 정보
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#15](https://github.com/dykim-base-project/claude-slack-to-notion/issues/15) |
+| 브랜치 | `refactor/15` |
+| 날짜 | 2026-02-15 |
+| 유형 | 리팩토링 |
+
+## 배경
+
+### 문제 인식
+
+이 프로젝트는 "Claude Code 플러그인"으로 설계되었지만, 실제로는 플러그인 표준 구조를 갖추고 있지 않았다.
+
+- `.claude-plugin/plugin.json` (플러그인 매니페스트) 없음
+- `.mcp.json` (MCP 서버 설정) 없음
+- `claude plugin add`로 설치 불가능한 상태
+- `src/` 에 핵심 Python 코드가 있었지만 플러그인으로 연결되지 않음
+
+기존 설치 방식은 `claude-devex`의 setup.sh를 통한 워크플로우 스킬 설치였는데, 이는 개발자 전용 도구이지 플러그인 사용자(비개발자)를 위한 것이 아니었다.
+
+### 전환 동기
+
+1. 비개발자가 `claude plugin add` 한 줄로 설치하고 바로 사용할 수 있어야 함
+2. Python 환경 문제는 비개발자에게 치명적 — venv로 격리 필요
+3. `src/`의 Slack 수집 코드를 MCP 도구로 노출해야 Claude가 직접 호출 가능
+
+## 설계 결정
+
+### 1. MCP 서버 방식 선택
+
+Python 코드를 플러그인에 연결하는 방식으로 **MCP 서버**를 선택했다.
+
+| 대안 | 장점 | 단점 | 선택 |
+|------|------|------|:----:|
+| MCP 서버 | Claude가 직접 도구 호출 가능, 자연어 통합 | MCP SDK 의존성 추가 | O |
+| Skills | 슬래시 커맨드로 호출 | 자연어 통합 안됨, 비개발자에게 어려움 | X |
+| Hooks | 이벤트 기반 자동 실행 | 이 프로젝트와 맞지 않음 | X |
+
+### 2. venv 자동 부트스트랩
+
+비개발자의 Python 환경 문제를 해결하기 위해:
+- MCP 서버 최초 실행 시 `scripts/run-server.sh`가 자동으로 venv 생성
+- 의존성 설치도 자동
+- 에러 메시지는 한글로, 해결 방법까지 안내
+
+### 3. macOS 우선 지원
+
+- Windows 지원은 별도 이슈로 분리
+- bash 스크립트 기반 부트스트랩
+
+### 4. devex 분리
+
+- 플러그인 사용자에게 devex는 불필요
+- README에서 devex 관련 내용 전면 제거
+- devex는 `.claude/` 디렉토리에서 개발자 전용으로만 유지
+
+## 구현 내역
+
+### 신규 파일
+
+| 파일 | 역할 |
+|------|------|
+| `.claude-plugin/plugin.json` | 플러그인 매니페스트 |
+| `.mcp.json` | MCP 서버 설정 (bash 부트스트랩 호출) |
+| `scripts/run-server.sh` | python3 확인, venv 생성, 의존성 설치, 서버 실행 |
+| `src/slack_to_notion/mcp_server.py` | MCP 서버 진입점 (Slack 도구 4개) |
+
+### 수정 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `pyproject.toml` | `mcp[cli]>=1.0.0` 의존성 추가 |
+| `README.md` | 플러그인 설치 가이드로 전면 재작성 |
+
+### MCP 도구 목록
+
+| 도구 | 기능 | 매핑 대상 |
+|------|------|-----------|
+| `list_channels` | 채널 목록 조회 | `SlackClient.list_channels()` |
+| `fetch_messages` | 채널 메시지 조회 | `SlackClient.fetch_channel_messages()` |
+| `fetch_thread` | 스레드 조회 | `SlackClient.fetch_thread_replies()` |
+| `fetch_channel_info` | 채널 정보 조회 | `SlackClient.fetch_channel_info()` |
+
+## 트러블슈팅
+
+(구현 중 발생한 이슈가 있으면 여기에 추가)
+
+## 결과
+
+- `claude plugin add`로 설치 가능한 표준 플러그인 구조 완성
+- 비개발자가 Python 환경 걱정 없이 사용 가능
+- Slack 수집 기능이 MCP 도구로 노출되어 Claude가 직접 호출 가능

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
     "slack_sdk>=3.27.0",
     "notion-client>=2.2.0",
-    "python-dotenv>=1.0.0",
+    "mcp[cli]>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+# PLUGIN_ROOT: 스크립트 위치 기준 상위 디렉토리
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PLUGIN_ROOT"
+
+# 1. python3 존재 확인
+if ! command -v python3 &> /dev/null; then
+    echo "[오류] python3이 설치되지 않았습니다." >&2
+    echo "설치 방법:" >&2
+    echo "  macOS: brew install python3" >&2
+    echo "  또는: https://www.python.org/downloads/" >&2
+    exit 1
+fi
+
+# 2. .venv 존재 확인 및 생성
+if [ ! -d ".venv" ]; then
+    echo "최초 실행: 환경을 설정하고 있습니다..." >&2
+    python3 -m venv .venv
+
+    if ! .venv/bin/pip install -e . >&2; then
+        echo "[오류] 패키지 설치에 실패했습니다." >&2
+        echo "네트워크 연결을 확인하거나, 관리자에게 문의하세요." >&2
+        exit 1
+    fi
+fi
+
+# 3. 패키지 설치 상태 검증 (venv는 있지만 패키지가 없는 경우 대비)
+if ! .venv/bin/python -c "import slack_to_notion" 2>/dev/null; then
+    echo "패키지를 재설치합니다..." >&2
+    if ! .venv/bin/pip install -e . >&2; then
+        echo "[오류] 패키지 재설치에 실패했습니다." >&2
+        exit 1
+    fi
+fi
+
+# 4. MCP 서버 실행 (stdout은 MCP 프로토콜 통신용)
+exec .venv/bin/python -m slack_to_notion.mcp_server

--- a/src/slack_to_notion/config.py
+++ b/src/slack_to_notion/config.py
@@ -1,13 +1,14 @@
-"""환경변수 로딩 및 설정 관리."""
+"""환경변수 설정 관리.
+
+플러그인 모드: .mcp.json의 env 섹션에서 환경변수 주입
+독립 실행 모드: export 또는 .env 파일로 환경변수 설정
+"""
 
 import os
-from pathlib import Path
-
-from dotenv import load_dotenv
 
 
 def load_config() -> dict:
-    """환경변수를 로딩하고 필수 값을 검증한다.
+    """환경변수를 검증하고 설정값을 반환한다.
 
     Returns:
         설정값 딕셔너리
@@ -15,9 +16,6 @@ def load_config() -> dict:
     Raises:
         SystemExit: 필수 환경변수가 누락된 경우 (비개발자 안내 메시지 포함)
     """
-    env_path = Path.cwd() / ".env"
-    load_dotenv(env_path)
-
     required_vars = {
         "SLACK_BOT_TOKEN": "Slack Bot 토큰",
         "NOTION_API_KEY": "Notion API 키",
@@ -28,7 +26,7 @@ def load_config() -> dict:
     missing = []
 
     for var, description in required_vars.items():
-        value = os.getenv(var)
+        value = os.environ.get(var)
         if not value:
             missing.append(f"  - {var}: {description}")
         else:
@@ -40,9 +38,10 @@ def load_config() -> dict:
         for item in missing:
             print(item)
         print("\n설정 방법:")
-        print("1. 프로젝트 루트의 .env.example 파일을 .env로 복사하세요")
-        print("2. .env 파일을 열어 각 항목에 값을 입력하세요")
-        print("3. 자세한 발급 방법은 README.md를 참고하세요\n")
+        print("  export SLACK_BOT_TOKEN=\"xoxb-...\"")
+        print("  export NOTION_API_KEY=\"secret_...\"")
+        print("  export NOTION_PARENT_PAGE_ID=\"...\"")
+        print("\n자세한 발급 방법은 README.md를 참고하세요.\n")
         raise SystemExit(1)
 
     return config

--- a/src/slack_to_notion/mcp_server.py
+++ b/src/slack_to_notion/mcp_server.py
@@ -1,0 +1,143 @@
+"""Slack-to-Notion MCP 서버.
+
+FastMCP를 사용하여 Slack 메시지 수집 기능을 MCP 도구로 제공한다.
+"""
+
+import json
+import logging
+import os
+import sys
+
+from mcp.server.fastmcp import FastMCP
+
+from .slack_client import SlackClient, SlackClientError
+
+# stdout은 MCP 프로토콜용이므로 로깅은 stderr로
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger(__name__)
+
+# MCP 서버 인스턴스
+mcp = FastMCP("slack-to-notion")
+
+# SlackClient 인스턴스 (lazy init)
+_slack_client: SlackClient | None = None
+
+
+def _get_slack_client() -> SlackClient:
+    """SlackClient 인스턴스를 반환한다. 없으면 초기화.
+
+    Returns:
+        SlackClient 인스턴스
+
+    Raises:
+        RuntimeError: SLACK_BOT_TOKEN이 설정되지 않은 경우
+    """
+    global _slack_client
+    if _slack_client is None:
+        token = os.environ.get("SLACK_BOT_TOKEN")
+        if not token:
+            raise RuntimeError(
+                "SLACK_BOT_TOKEN 환경변수가 설정되지 않았습니다. "
+                ".mcp.json 파일의 env 섹션을 확인하세요."
+            )
+        _slack_client = SlackClient(token)
+        logger.info("SlackClient 초기화 완료")
+    return _slack_client
+
+
+@mcp.tool()
+def list_channels() -> str:
+    """Slack 채널 목록을 조회한다.
+
+    Returns:
+        채널 정보 리스트를 JSON 형식 문자열로 반환
+        [{"id": "C123", "name": "general", "topic": "...", "num_members": 10}]
+    """
+    try:
+        client = _get_slack_client()
+        channels = client.list_channels()
+        return json.dumps(channels, ensure_ascii=False, indent=2)
+    except SlackClientError as e:
+        return f"[에러] {e.message}"
+    except Exception as e:
+        logger.exception("예상치 못한 에러 발생")
+        return f"[에러] 채널 목록 조회 실패: {e!s}"
+
+
+@mcp.tool()
+def fetch_messages(
+    channel_id: str,
+    limit: int = 100,
+    oldest: str | None = None,
+) -> str:
+    """Slack 채널의 메시지를 조회한다.
+
+    Args:
+        channel_id: 채널 ID (예: C0123456789)
+        limit: 조회할 메시지 수 (기본값: 100)
+        oldest: 시작 타임스탬프 (해당 시점 이후 메시지만 조회)
+
+    Returns:
+        메시지 리스트를 JSON 형식 문자열로 반환
+    """
+    try:
+        client = _get_slack_client()
+        messages = client.fetch_channel_messages(channel_id, limit, oldest)
+        return json.dumps(messages, ensure_ascii=False, indent=2)
+    except SlackClientError as e:
+        return f"[에러] {e.message}"
+    except Exception as e:
+        logger.exception("예상치 못한 에러 발생")
+        return f"[에러] 메시지 조회 실패: {e!s}"
+
+
+@mcp.tool()
+def fetch_thread(channel_id: str, thread_ts: str) -> str:
+    """Slack 스레드의 메시지를 조회한다.
+
+    Args:
+        channel_id: 채널 ID (예: C0123456789)
+        thread_ts: 스레드 타임스탬프 (예: 1234567890.123456)
+
+    Returns:
+        스레드 메시지 리스트를 JSON 형식 문자열로 반환
+    """
+    try:
+        client = _get_slack_client()
+        messages = client.fetch_thread_replies(channel_id, thread_ts)
+        return json.dumps(messages, ensure_ascii=False, indent=2)
+    except SlackClientError as e:
+        return f"[에러] {e.message}"
+    except Exception as e:
+        logger.exception("예상치 못한 에러 발생")
+        return f"[에러] 스레드 조회 실패: {e!s}"
+
+
+@mcp.tool()
+def fetch_channel_info(channel_id: str) -> str:
+    """Slack 채널의 상세 정보를 조회한다.
+
+    Args:
+        channel_id: 채널 ID (예: C0123456789)
+
+    Returns:
+        채널 정보를 JSON 형식 문자열로 반환
+    """
+    try:
+        client = _get_slack_client()
+        info = client.fetch_channel_info(channel_id)
+        return json.dumps(info, ensure_ascii=False, indent=2)
+    except SlackClientError as e:
+        return f"[에러] {e.message}"
+    except Exception as e:
+        logger.exception("예상치 못한 에러 발생")
+        return f"[에러] 채널 정보 조회 실패: {e!s}"
+
+
+if __name__ == "__main__":
+    logger.info("Slack-to-Notion MCP 서버 시작")
+    mcp.run()


### PR DESCRIPTION
## Summary

- 비개발자가 `claude --plugin-dir`로 설치하여 바로 사용할 수 있는 Claude Code 플러그인 표준 구조로 전환
- `src/` Python 코드를 MCP 서버로 노출하여 Claude가 Slack 도구를 직접 호출 가능
- venv 자동 부트스트랩으로 Python 환경 문제를 사용자에게 노출하지 않음

## 배경

이 프로젝트는 "Claude Code 플러그인"으로 설계되었으나, 실제 플러그인 표준 구조(`.claude-plugin/plugin.json`, `.mcp.json`)가 없어 `claude plugin install`로 설치할 수 없는 상태였다. 기존 설치 방식은 devex의 `setup.sh`로 워크플로우 스킬만 설치하는 것이었으며, 핵심 Python 코드(`src/`)는 플러그인과 연결되지 않았다.

## 설계 결정

### 1. MCP 서버 방식 선택
| 대안 | 선택 | 이유 |
|------|:----:|------|
| MCP 서버 | O | Claude가 자연어로 도구 호출 가능, 비개발자 친화적 |
| Skills | X | 슬래시 커맨드 필요, 자연어 통합 불가 |
| Hooks | X | 이벤트 기반으로 이 프로젝트에 부적합 |

### 2. venv 자동 부트스트랩 (`scripts/run-server.sh`)
- MCP 서버 최초 실행 시 자동으로 venv 생성 + 의존성 설치
- 비개발자가 Python 환경을 직접 관리할 필요 없음
- 에러 메시지는 한글로, 해결 방법까지 안내

### 3. config.py 리팩터링
- `python-dotenv` 의존성 제거 → `os.environ` 직접 참조
- 플러그인 모드(`.mcp.json` env 주입)와 독립 실행 모드(`export`) 모두 호환

### 4. 설치 명령어 결정
- 마켓플레이스 미등록 상태이므로 `claude --plugin-dir` (로컬 설치) 채택
- 마켓플레이스 등록 시 `claude plugin install`로 전환 예정

## 아키텍트 리뷰 과정

1차 리뷰: **REJECTED** (3개 블로킹 이슈)
- `claude plugin add` → 존재하지 않는 명령어 → `claude --plugin-dir`로 수정
- `config.py` dotenv 의존 → `os.environ` 직접 참조로 리팩터링
- `analyzer.py` 의도치 않은 삭제 → main에서 복원

2차 리뷰: **APPROVED** (모든 블로킹 이슈 해소, 비블로킹 권고사항도 반영)

## 변경 파일

### 신규 (5개)
| 파일 | 역할 |
|------|------|
| `.claude-plugin/plugin.json` | 플러그인 매니페스트 |
| `.mcp.json` | MCP 서버 설정 (bash 부트스트랩 호출) |
| `scripts/run-server.sh` | python3 확인, venv 생성, 의존성 설치, 서버 실행 |
| `src/slack_to_notion/mcp_server.py` | FastMCP 기반 MCP 서버 (Slack 도구 4개) |
| `docs/dev-log/issue-15.md` | 블로그용 개발 과정 기록 |

### 수정 (3개)
| 파일 | 변경 |
|------|------|
| `pyproject.toml` | `python-dotenv` → `mcp[cli]>=1.0.0` |
| `README.md` | devex 기반 → 플러그인 설치 가이드로 전면 재작성 |
| `config.py` | dotenv 제거, os.environ 직접 참조 |

### MCP 도구
| 도구 | 설명 |
|------|------|
| `list_channels` | Slack 채널 목록 조회 |
| `fetch_messages` | 채널 메시지 조회 |
| `fetch_thread` | 스레드 조회 |
| `fetch_channel_info` | 채널 정보 조회 |

## 제약사항
- macOS/Linux 전용 (Windows 지원은 별도 이슈)
- 마켓플레이스 미등록 (로컬 설치만 가능)

## Test plan

- [ ] `scripts/run-server.sh` 실행 시 venv 자동 생성 확인
- [ ] venv 생성 후 `python -m slack_to_notion.mcp_server` 정상 기동 확인
- [ ] SLACK_BOT_TOKEN 미설정 시 한글 에러 메시지 출력 확인
- [ ] `claude --plugin-dir ./claude-slack-to-notion` 으로 플러그인 로드 확인

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin now installable as a standard Claude plugin with MCP server architecture.
  * MCP server exposes tools for Slack channel listing, message fetching, thread retrieval, and channel information.
  * Automatic Python environment bootstrap on first run.

* **Documentation**
  * Comprehensive README with clear setup instructions, API token configuration, and workflow examples.
  * Development documentation for MCP architecture.

* **Chores**
  * Configuration simplified to environment variables.
  * Updated dependencies and manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->