### PR TITLE
feat: 분석 커스터마이징 및 히스토리 조회 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,14 @@ Slack #general 채널 메시지 조회해줘
 | `create_notion_page` | 분석 결과를 Notion 페이지로 생성 |
 | `save_analysis_result` | 분석 결과를 로컬 JSON 파일로 백업 |
 
+**커스터마이징**
+
+| 도구 | 설명 |
+|------|------|
+| `save_preference_tool` | 사용자의 분석 선호도 저장 ("기억해줘", "앞으로 ~해줘") |
+| `get_preferences` | 저장된 분석 선호도 조회 (분석 전 자동 참조) |
+| `list_analysis_history` | 과거 분석 결과 히스토리 조회 ("지난번처럼 해줘") |
+
 ### 제약사항
 
 - **플랫폼**: macOS/Linux만 지원 (Windows 지원 예정)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -128,6 +128,58 @@ class TestFetchThreads:
             assert "Channel: C0AF01XMZB8" in result
 
 
+class TestSavePreferenceTool:
+    """save_preference_tool 도구 테스트."""
+
+    def test_success(self, tmp_path):
+        pref_path = tmp_path / "preferences.md"
+        with patch("slack_to_notion.mcp_server.save_preference") as mock_save:
+            mock_save.return_value = pref_path
+            from slack_to_notion.mcp_server import save_preference_tool
+            result = save_preference_tool("회의록 위주로 정리해줘")
+            assert "저장되었습니다" in result
+            mock_save.assert_called_once_with("회의록 위주로 정리해줘")
+
+
+class TestGetPreferences:
+    """get_preferences 도구 테스트."""
+
+    def test_with_preferences(self):
+        with patch("slack_to_notion.mcp_server.load_preferences") as mock_load:
+            mock_load.return_value = "## 분석 선호도\n\n- [2026-02-16] 결정사항 위주로\n"
+            from slack_to_notion.mcp_server import get_preferences
+            result = get_preferences()
+            assert "분석 선호도" in result
+
+    def test_empty(self):
+        with patch("slack_to_notion.mcp_server.load_preferences") as mock_load:
+            mock_load.return_value = ""
+            from slack_to_notion.mcp_server import get_preferences
+            result = get_preferences()
+            assert "없습니다" in result
+
+
+class TestListAnalysisHistory:
+    """list_analysis_history 도구 테스트."""
+
+    def test_with_history(self):
+        with patch("slack_to_notion.mcp_server.list_history") as mock_list:
+            mock_list.return_value = [
+                {"filename": "analysis_20260216.json", "path": "/tmp/a.json", "summary": "마케팅 분석"},
+            ]
+            from slack_to_notion.mcp_server import list_analysis_history
+            result = list_analysis_history()
+            assert "1건" in result
+            assert "마케팅 분석" in result
+
+    def test_empty(self):
+        with patch("slack_to_notion.mcp_server.list_history") as mock_list:
+            mock_list.return_value = []
+            from slack_to_notion.mcp_server import list_analysis_history
+            result = list_analysis_history()
+            assert "없습니다" in result
+
+
 class TestCreateNotionPageBlockConversion:
     """페이지 생성 시 블록 변환이 올바르게 전달되는지 테스트."""
 


### PR DESCRIPTION
## Summary

- 사용자 분석 선호도 저장/조회 기능 추가 (자연어 기반: "기억해줘", "앞으로 ~해줘")
- 과거 분석 히스토리 목록 조회 기능 추가 ("지난번처럼 해줘")
- MCP 도구 3개 추가: `save_preference_tool`, `get_preferences`, `list_analysis_history`

## Changes

| 파일 | 내용 |
|------|------|
| `analyzer.py` | `save_preference`, `load_preferences`, `list_history` 함수 추가 |
| `mcp_server.py` | MCP 도구 3개 추가 (커스터마이징 섹션) |
| `test_analyzer.py` | preference/history 테스트 13건 추가 |
| `test_mcp_server.py` | 새 도구 테스트 5건 추가 |
| `README.md` | 커스터마이징 도구 테이블 추가 |

## Test plan

- [x] 단위 테스트 86건 전체 통과 (기존 68 + 신규 18)
- [ ] E2E: `save_preference_tool` 호출 → `preferences.md` 생성 확인
- [ ] E2E: `get_preferences` 호출 → 저장된 선호도 반환 확인
- [ ] E2E: `list_analysis_history` 호출 → 히스토리 목록 반환 확인

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Save and manage analysis preferences to remember your settings and personalize workflows
  * Automatically retrieve stored preferences for consistent behavior across future analyses
  * Access past analysis history to reference and reuse previous work

* **Documentation**
  * Updated README documenting new preference and history management capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->