### PR TITLE
feat: Slack 사용자 토큰(xoxp) 지원 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@
 # Slack App 생성 후 Bot User OAuth Token을 입력하세요.
 SLACK_BOT_TOKEN=
 
+# Slack 사용자 토큰 (xoxp-로 시작) — Bot 토큰 대신 사용 가능
+# Bot을 채널에 추가하기 어려운 경우, 본인 계정의 User OAuth Token을 사용할 수 있습니다.
+# SLACK_BOT_TOKEN과 동시에 설정하면 Bot 토큰이 우선 사용됩니다.
+# SLACK_USER_TOKEN=
+
 # Notion API 키 (secret_로 시작)
 # Notion Integration 생성 후 Internal Integration Secret을 입력하세요.
 NOTION_API_KEY=

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,6 +5,7 @@
       "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/run-server.sh"],
       "env": {
         "SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}",
+        "SLACK_USER_TOKEN": "${SLACK_USER_TOKEN}",
         "NOTION_API_KEY": "${NOTION_API_KEY}",
         "NOTION_PARENT_PAGE_ID": "${NOTION_PARENT_PAGE_ID}"
       }

--- a/src/slack_to_notion/config.py
+++ b/src/slack_to_notion/config.py
@@ -17,7 +17,6 @@ def load_config() -> dict:
         SystemExit: 필수 환경변수가 누락된 경우 (비개발자 안내 메시지 포함)
     """
     required_vars = {
-        "SLACK_BOT_TOKEN": "Slack Bot 토큰",
         "NOTION_API_KEY": "Notion API 키",
         "NOTION_PARENT_PAGE_ID": "Notion 상위 페이지 ID",
     }
@@ -32,13 +31,25 @@ def load_config() -> dict:
         else:
             config[var] = value
 
+    # Slack 토큰 검증: 봇 토큰 또는 사용자 토큰 중 하나 필수
+    slack_bot_token = os.environ.get("SLACK_BOT_TOKEN")
+    slack_user_token = os.environ.get("SLACK_USER_TOKEN")
+    if not slack_bot_token and not slack_user_token:
+        missing.append("  - SLACK_BOT_TOKEN 또는 SLACK_USER_TOKEN: Slack 토큰")
+
+    if slack_bot_token:
+        config["SLACK_BOT_TOKEN"] = slack_bot_token
+    elif slack_user_token:
+        config["SLACK_USER_TOKEN"] = slack_user_token
+
     if missing:
         print("\n[설정 오류] 필수 환경변수가 설정되지 않았습니다.\n")
         print("누락된 항목:")
         for item in missing:
             print(item)
         print("\n설정 방법:")
-        print("  export SLACK_BOT_TOKEN=\"xoxb-...\"")
+        print("  export SLACK_BOT_TOKEN=\"xoxb-...\"  # 봇 토큰 (권장)")
+        print("  export SLACK_USER_TOKEN=\"xoxp-...\"  # 사용자 토큰 (대안)")
         print("  export NOTION_API_KEY=\"secret_...\"")
         print("  export NOTION_PARENT_PAGE_ID=\"...\"")
         print("\n자세한 발급 방법은 README.md를 참고하세요.\n")


### PR DESCRIPTION
## Summary

- Slack 사용자 토큰(`xoxp-`) 지원 추가 (기존 봇 토큰과 택 1)
- 봇 토큰(기본 권장) → 사용자 토큰(대안) 우선순위로 동작
- 토큰 접두사(`xoxb-`/`xoxp-`)로 타입 자동 판별, 에러 메시지 분기
- README에 방식 A(봇)/방식 B(사용자) 비교표 및 가이드 추가

### 설계 배경

| | Bot 토큰 (권장) | 사용자 토큰 (대안) |
|---|---|---|
| 채널 접근 | 채널에 앱 추가 필요 | 본인 참여 채널에 바로 접근 |
| 설정 공유 | 한 명이 설정 후 `.env` 공유 가능 | 각자 본인 토큰 발급 |
| 지속성 | 채널이 있는 한 계속 동작 | 발급자가 떠나면 중단 |
| 적합한 경우 | 팀 사용, 안정적 운영 | 혼자 빠르게 시작, 앱 추가가 어려운 채널 |

## Test plan

- [x] 기존 86개 테스트 전체 통과 (하위 호환 확인)
- [ ] `SLACK_BOT_TOKEN`만 설정 시 기존과 동일 동작 확인
- [ ] `SLACK_USER_TOKEN`만 설정 시 사용자 토큰으로 초기화 확인
- [ ] 양쪽 모두 미설정 시 에러 메시지 확인

closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Slack User Token (xoxp-) as an alternative to Bot Token for authentication. Users can now choose either token type; Bot Token takes precedence if both are configured.

* **Documentation**
  * Updated setup guides to clarify token configuration options and added specific instructions for both Bot and User token flows. Improved error messages to provide token-type-specific guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->