### PR TITLE
fix: 에러 메시지 한글화 누락 및 limit=0 검증 (#53)

### DIFF
--- a/src/slack_to_notion/mcp_server.py
+++ b/src/slack_to_notion/mcp_server.py
@@ -118,6 +118,7 @@ def fetch_messages(
     """
     try:
         client = _get_slack_client()
+        limit = max(1, min(limit, 1000))
         messages = client.fetch_channel_messages(channel_id, limit, oldest)
         return json.dumps(messages, ensure_ascii=False, indent=2)
     except SlackClientError as e:

--- a/src/slack_to_notion/notion_client.py
+++ b/src/slack_to_notion/notion_client.py
@@ -76,8 +76,10 @@ class NotionClient:
             return "Notion 페이지를 찾을 수 없습니다. Integration이 해당 페이지에 연결되어 있는지 확인하세요."
         elif code == "restricted_resource":
             return "해당 Notion 페이지에 접근 권한이 없습니다. Integration 연결을 확인하세요."
+        elif code == "validation_error":
+            return "Notion 요청이 올바르지 않습니다. NOTION_PARENT_PAGE_ID가 유효한 페이지 ID인지 확인하세요."
         else:
-            return f"Notion API 오류가 발생했습니다: {code}. 자세한 내용은 README.md를 참고하세요."
+            return f"예상치 못한 오류가 발생했습니다 ({code}). 문제가 지속되면 README.md를 참고하세요."
 
     def check_duplicate(self, parent_page_id: str, title: str) -> bool:
         """상위 페이지 하위에서 동일 제목의 페이지가 있는지 확인."""

--- a/src/slack_to_notion/slack_client.py
+++ b/src/slack_to_notion/slack_client.py
@@ -177,4 +177,7 @@ class SlackClient:
                 return "사용자 토큰에 필요한 권한이 없습니다. Slack App 설정에서 User Token Scopes를 추가하세요."
             return "Bot에 필요한 권한이 없습니다. Slack App 설정에서 channels:history, channels:read 권한을 추가하세요."
 
-        return f"Slack API 오류가 발생했습니다: {error_code}. 자세한 내용은 README.md를 참고하세요."
+        if error_code == "thread_not_found":
+            return "해당 스레드를 찾을 수 없습니다. 스레드 타임스탬프가 올바른지 확인하세요."
+
+        return f"예상치 못한 오류가 발생했습니다 ({error_code}). 문제가 지속되면 README.md를 참고하세요."


### PR DESCRIPTION
## Summary
- Slack `thread_not_found` 에러 메시지 한글화 추가
- Notion `validation_error` 에러 메시지 한글화 추가
- 공통 폴백 메시지 개선 ("예상치 못한 오류가 발생했습니다")
- `fetch_messages` limit 값 1~1000 범위로 클램핑

## Test plan
- [x] 기존 테스트 86건 전체 통과

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message fetching reliability by validating request limits are within acceptable ranges.
  * Enhanced error messaging for Notion page configuration issues to provide clearer guidance.
  * Added specific error handling for missing Slack threads with improved user feedback.
  * Updated generic error messages across API interactions for better clarity and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->