### PR TITLE
chore: PyPI 배포를 위한 패키지 메타데이터 보완

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 dykim-base-project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Slack 메시지/스레드를 분석하여 Notion 페이지로 정리하는 MCP 서버"
 requires-python = ">=3.10"
 license = "MIT"
+readme = "README.md"
 authors = [{ name = "dykim-base-project" }]
 keywords = ["slack", "notion", "mcp", "claude-code"]
 classifiers = [


### PR DESCRIPTION
## Summary
- pyproject.toml에 `readme = "README.md"` 필드 추가 (PyPI 프로젝트 페이지에 설명 표시)
- MIT LICENSE 파일 생성 (pyproject.toml의 `license = "MIT"` 선언에 대응)

## 관련 이슈
Closes #58

## 후속 작업 (수동)
1. PyPI에서 API 토큰 발급 → GitHub Secrets에 `PYPI_API_TOKEN` 등록
2. main 머지 후 `v0.1.0` 태그 push → GitHub Actions 배포 트리거

## Test plan
- [x] `uv build` 로컬 빌드 성공 확인
- [x] README.md가 패키지 메타데이터에 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MIT License establishing standard permissions and warranty disclaimer
  * Updated project metadata configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->