### PR TITLE
fix: Notion API Key ntn_ 프리픽스 지원 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ SLACK_BOT_TOKEN=
 # SLACK_BOT_TOKEN과 동시에 설정하면 Bot 토큰이 우선 사용됩니다.
 # SLACK_USER_TOKEN=
 
-# Notion API 키 (secret_로 시작)
+# Notion API 키 (ntn_ 또는 secret_로 시작)
 # Notion Integration 생성 후 Internal Integration Secret을 입력하세요.
 NOTION_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ claude mcp add slack-to-notion \
 |------|------|------|
 | `SLACK_BOT_TOKEN` | Slack 채널 메시지 읽기 (권장) | `xoxb-`로 시작 |
 | `SLACK_USER_TOKEN` | Slack 채널 메시지 읽기 (대안) | `xoxp-`로 시작 |
-| `NOTION_API_KEY` | Notion 페이지 생성 | `secret_`로 시작 |
+| `NOTION_API_KEY` | Notion 페이지 생성 | `ntn_` 또는 `secret_`로 시작 |
 | `NOTION_PARENT_PAGE_ID` | 분석 결과가 저장될 Notion 페이지 | 페이지 링크 또는 32자 ID |
 
 > `SLACK_BOT_TOKEN`과 `SLACK_USER_TOKEN` 중 **하나만 설정**하면 됩니다. 둘 다 설정하면 Bot 토큰이 사용됩니다.
@@ -195,7 +195,7 @@ Notion Integration은 분석 결과를 Notion 페이지로 작성하는 역할�
    - **이름**: Integration 이름 (예: `slack-analyzer`)
    - **연결된 워크스페이스**: 사용할 Notion 워크스페이스 선택
 5. **"저장"** 클릭
-6. **"내부 통합 시크릿"** 이 표시됩니다. **"표시"** → 복사 버튼을 눌러 토큰을 복사합니다. (`secret_`로 시작하는 문자열)
+6. **"내부 통합 시크릿"** 이 표시됩니다. **"표시"** → 복사 버튼을 눌러 토큰을 복사합니다. (`ntn_` 또는 `secret_`로 시작하는 문자열)
 
 > 시크릿 조회 시 400 에러가 발생하면 **시크릿 브라우징(incognito)** 모드에서 다시 시도하세요. 브라우저 캐시나 확장 프로그램이 간섭할 수 있습니다.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -98,17 +98,17 @@ done
 # ============================================================
 print_step "[2/3] Notion API Key 입력"
 echo "  Notion Integration에서 발급받은 Internal Integration Token을 입력하세요."
-echo "  (secret_로 시작하는 값)"
+echo "  (ntn_ 또는 secret_로 시작하는 값)"
 
 while true; do
   printf "  Notion API Key: "
   read -r notion_api_key < /dev/tty
 
-  if [[ "$notion_api_key" == secret_* ]]; then
+  if [[ "$notion_api_key" == ntn_* ]] || [[ "$notion_api_key" == secret_* ]]; then
     print_ok "Notion API Key 확인"
     break
   else
-    print_err "올바른 형식이 아닙니다. secret_ 로 시작해야 합니다."
+    print_err "올바른 형식이 아닙니다. ntn_ 또는 secret_ 로 시작해야 합니다."
     echo "    토큰 발급 가이드: ${GUIDE_URL}"
   fi
 done

--- a/src/slack_to_notion/config.py
+++ b/src/slack_to_notion/config.py
@@ -50,7 +50,7 @@ def load_config() -> dict:
         print("\n설정 방법:")
         print("  export SLACK_BOT_TOKEN=\"xoxb-...\"  # 봇 토큰 (권장)")
         print("  export SLACK_USER_TOKEN=\"xoxp-...\"  # 사용자 토큰 (대안)")
-        print("  export NOTION_API_KEY=\"secret_...\"")
+        print("  export NOTION_API_KEY=\"ntn_...\"  # 또는 secret_...")
         print("  export NOTION_PARENT_PAGE_ID=\"...\"")
         print("\n자세한 발급 방법은 README.md를 참고하세요.\n")
         raise SystemExit(1)


### PR DESCRIPTION
## Summary

- Notion이 Internal Integration Secret 형식을 `secret_` → `ntn_`로 변경하여 발생한 설치 블로커 수정
- `scripts/setup.sh`, `config.py`, `README.md`, `.env.example` 4개 파일에서 `ntn_` 프리픽스 허용
- 기존 `secret_` 형식도 하위 호환 유지

## Test plan

- [ ] `scripts/setup.sh`에서 `ntn_` 키 입력 시 정상 통과 확인
- [ ] `scripts/setup.sh`에서 `secret_` 키 입력 시 여전히 정상 통과 확인
- [ ] `config.py` 안내 메시지에 `ntn_` 형식 표기 확인

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)