### PR TITLE
fix: 마크다운 인라인 문법 Notion rich_text 변환 지원 (#85)

### DIFF
--- a/src/slack_to_notion/mcp_server.py
+++ b/src/slack_to_notion/mcp_server.py
@@ -294,7 +294,7 @@ def create_notion_page(
 
     Args:
         title: 페이지 제목 (예: "[general] 분석 결과 - 2024-01-15")
-        content: 분석 결과 텍스트 (마크다운 형식 지원: #, ##, ###, -, *)
+        content: 분석 결과 텍스트 (마크다운 형식 지원: #, ##, ###, -, *, **, `코드`, [링크](url), ~~취소선~~)
 
     Returns:
         생성된 Notion 페이지 URL 또는 에러 메시지

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -23,7 +23,7 @@ class TestCreateNotionPage:
              patch("slack_to_notion.notion_client.Client") as mock_cls:
             mock_api = mock_cls.return_value
             mock_api.blocks.children.list.return_value = {"results": []}
-            mock_api.pages.create.return_value = {"url": "https://notion.so/created-page"}
+            mock_api.pages.create.return_value = {"id": "fake-page-id", "url": "https://notion.so/created-page"}
 
             from slack_to_notion.mcp_server import create_notion_page
             result = create_notion_page(title, content)
@@ -194,7 +194,7 @@ class TestCreateNotionPageBlockConversion:
              patch("slack_to_notion.notion_client.Client") as mock_cls:
             mock_api = mock_cls.return_value
             mock_api.blocks.children.list.return_value = {"results": []}
-            mock_api.pages.create.return_value = {"url": "https://notion.so/page"}
+            mock_api.pages.create.return_value = {"id": "fake-page-id", "url": "https://notion.so/page"}
 
             from slack_to_notion.mcp_server import create_notion_page
             create_notion_page("제목", "# 헤딩\n- 항목")


### PR DESCRIPTION
## Summary
- `split_rich_text()`에 인라인 마크다운 파싱 추가 (링크, 볼드, 이탤릭, 인라인 코드, 취소선)
- `create_notion_page` 도구 설명에 지원 문법 명시
- 테스트 mock에 `"id"` 필드 누락 회귀 버그 수정 (#80 머지로 발생)
- 인라인 파싱 테스트 10건 추가

## Test plan
- [x] 기존 테스트 전체 통과 (146 passed)
- [x] 인라인 마크다운 파싱 테스트 추가 (링크, 볼드, 이탤릭, 코드, 취소선, 혼합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)