### PR TITLE
fix: user_name 필터 누락 수정 + 테스트 10건 보완 (#91)

### DIFF
--- a/src/slack_to_notion/mcp_server.py
+++ b/src/slack_to_notion/mcp_server.py
@@ -123,7 +123,7 @@ def fetch_messages(
         messages = client.fetch_channel_messages(channel_id, limit, oldest)
         client.resolve_user_names(messages)
         filtered = [
-            {k: m[k] for k in ("ts", "user", "text", "reply_count", "thread_ts") if k in m}
+            {k: m[k] for k in ("ts", "user", "user_name", "text", "reply_count", "thread_ts") if k in m}
             for m in messages
         ]
         return json.dumps(filtered, ensure_ascii=False)
@@ -150,7 +150,7 @@ def fetch_thread(channel_id: str, thread_ts: str) -> str:
         messages = client.fetch_thread_replies(channel_id, thread_ts)
         client.resolve_user_names(messages)
         filtered = [
-            {k: m[k] for k in ("ts", "user", "text", "reply_count", "thread_ts") if k in m}
+            {k: m[k] for k in ("ts", "user", "user_name", "text", "reply_count", "thread_ts") if k in m}
             for m in messages
         ]
         return json.dumps(filtered, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- `fetch_messages`/`fetch_thread` 필드 필터에 `user_name` 추가 (resolve_user_names API 호출 결과 활용)
- 마크다운 엣지 케이스 테스트 6건 추가 (미닫힘, 빈 볼드, 빈 코드, URL 쿼리파라미터, 연속 볼드, 특수문자)
- 필드 필터링 정상 응답 테스트 1건 추가
- 100블록 경계값 테스트 3건 추가 (101개, 200개, 0개)

## Test plan
- [x] 156 tests 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated message field filtering to return standardized field names for better data consistency.

* **Tests**
  * Added comprehensive test coverage for message field filtering behavior.
  * Added extensive tests for Notion client parsing, Rich Text handling, and page creation logic including pagination and block management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->