### PR TITLE
chore: PyPI 배포 워크플로우 검증 강화 (#86)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,7 +6,36 @@ on:
       - "v*"
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: uv 설치
+        uses: astral-sh/setup-uv@v4
+
+      - name: 태그-버전 일치 확인
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(uv run python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          ")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::태그($TAG_VERSION)와 pyproject.toml 버전($PKG_VERSION)이 불일치합니다."
+            exit 1
+          fi
+          echo "버전 일치 확인: $TAG_VERSION"
+
+      - name: 의존성 설치
+        run: uv sync --extra dev
+
+      - name: 테스트 실행
+        run: uv run pytest tests/ -v
+
   publish:
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- 태그 push 시 배포 전 `validate` job 추가
- 태그 버전 ↔ `pyproject.toml` 버전 일치 검증
- `pytest` 테스트 통과 확인 후에만 배포 진행

## Test plan
- [ ] `v*` 태그 push 시 validate → publish 순서로 실행되는지 확인
- [ ] 버전 불일치 시 배포 차단되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)