### PR TITLE
chore: 버전 범프 0.1.0 → 0.2.0 — PyPI 배포용 (#98)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-to-notion-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "Slack 메시지/스레드를 분석하여 Notion 페이지로 정리하는 MCP 서버"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## Summary
- `pyproject.toml` 버전 `0.1.0` → `0.2.0` 범프
- main에 머지된 다수 개선사항(#77, #85, #92 등)을 PyPI 배포하여 사용자에게 전달

## Test plan
- [x] pytest 156건 전체 통과
- [ ] PR 머지 후 `v0.2.0` 태그 push → GitHub Actions PyPI 배포 확인
- [ ] `uvx --reinstall slack-to-notion-mcp`로 새 버전 설치 확인

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version number updated to 0.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->