### PR TITLE
fix: setup.sh uvx --reinstall 미지원 대응 + README 업데이트 안내 보완 (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,14 @@ curl -sL https://raw.githubusercontent.com/dykim-base-project/claude-slack-to-no
 이미 설치된 경우 동일한 명령으로 업데이트할 수 있습니다:
 
 ```bash
+# 방법 1: setup.sh (토큰 자동 재사용)
 curl -sL https://raw.githubusercontent.com/dykim-base-project/claude-slack-to-notion/main/scripts/setup.sh | bash
+
+# 방법 2: uvx 직접 실행 (캐시 초기화 후 최신 버전)
+uv cache clean slack-to-notion-mcp && uvx slack-to-notion-mcp@latest --help
 ```
 
-기존 설치가 감지되면 자동으로 업데이트 모드로 전환됩니다.
+setup.sh는 기존 설치를 감지하면 자동으로 업데이트 모드로 전환됩니다.
 기존 토큰은 자동으로 재사용되므로 토큰을 다시 입력하지 않아도 됩니다.
 
 #### 방법 3: 수동 등록 (고급)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -194,12 +194,8 @@ except:
   fi
 
   print_step "uvx 캐시 갱신 중..."
-  if uvx --reinstall slack-to-notion-mcp --help &>/dev/null 2>&1; then
-    print_ok "uvx 캐시 갱신 완료 (--reinstall)"
-  else
-    uv cache clean slack-to-notion-mcp 2>/dev/null || true
-    print_ok "uvx 캐시 갱신 완료 (cache clean)"
-  fi
+  uv cache clean slack-to-notion-mcp 2>/dev/null || true
+  print_ok "uvx 캐시 갱신 완료"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary
- `setup.sh`의 `uvx --reinstall` → `uv cache clean`으로 단순화 (uvx에서 --reinstall 플래그 제거됨)
- README 업데이트 섹션에 `uvx` 직접 실행 방법 추가

## Test plan
- [x] pytest 156건 전체 통과
- [x] `uv cache clean slack-to-notion-mcp` 정상 동작 확인 (v0.2.0 배포 시 검증)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and update instructions with new methods and clarified token reuse behavior.

* **Improvements**
  * Simplified the update process for more reliable cache management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->