### PR TITLE
fix: setup.sh uv cache clean --force 누락으로 업데이트 시 무한 대기 (#102)

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -194,7 +194,7 @@ except:
   fi
 
   print_step "uvx 캐시 갱신 중..."
-  uv cache clean slack-to-notion-mcp 2>/dev/null || true
+  uv cache clean slack-to-notion-mcp --force 2>/dev/null || true
   print_ok "uvx 캐시 갱신 완료"
 fi
 


### PR DESCRIPTION
## Summary
- `uv cache clean slack-to-notion-mcp` → `uv cache clean slack-to-notion-mcp --force`
- MCP 서버 실행 중 캐시 잠금으로 무한 대기하는 문제 해결

## Test plan
- [x] pytest 156건 전체 통과
- [x] `uv cache clean slack-to-notion-mcp --force` 즉시 완료 확인

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated setup script to forcibly refresh cache during initialization for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->