### PR TITLE
chore: PyPI 배포 태그 자동화 — auto-tag GitHub Actions 추가

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,47 @@
+name: Auto Tag
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "pyproject.toml"
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # PAT 사용: GITHUB_TOKEN으로 생성한 태그는 다른 워크플로우를 트리거하지 않음.
+          # PAT(Personal Access Token)로 체크아웃하면 해당 토큰으로 태그가 push되어
+          # pypi-publish.yml의 on.push.tags 트리거가 정상 동작함.
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: pyproject.toml에서 버전 읽기
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*= *"\(.*\)"/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: 태그 중복 확인
+        id: check
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "태그 $TAG 가 이미 존재합니다. 스킵합니다."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "태그 $TAG 를 생성합니다."
+          fi
+
+      - name: 태그 생성 및 push
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## Summary
- `pyproject.toml` version 변경이 main에 머지되면 태그를 자동 생성하는 GitHub Actions 워크플로우 추가
- 배포 파이프라인의 유일한 수동 단계(태그 push) 제거
- `PAT_TOKEN` 시크릿 필요 (GITHUB_TOKEN은 다른 워크플로우 트리거 불가)

## Test plan
- [ ] repo Settings에 `PAT_TOKEN` 시크릿 등록
- [ ] pyproject.toml version 변경 PR 머지 후 auto-tag 동작 확인
- [ ] 생성된 태그로 pypi-publish.yml 자동 트리거 확인

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated semantic versioning workflow that creates git tags based on version updates in the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->