### PR TITLE
docs: 유저 토큰 우선 안내, 봇 토큰 옵셔널로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Claude Desktop 앱의 메뉴에서 **Settings** → **Developer** → **Edit Con
       "command": "uvx",
       "args": ["slack-to-notion-mcp"],
       "env": {
-        "SLACK_BOT_TOKEN": "xoxb-토큰값을-여기에-입력",
+        "SLACK_USER_TOKEN": "xoxp-토큰값을-여기에-입력",
         "NOTION_API_KEY": "secret_토큰값을-여기에-입력",
         "NOTION_PARENT_PAGE_ID": "https://www.notion.so/페이지-링크를-여기에-붙여넣기"
       }
@@ -47,7 +47,7 @@ Claude Desktop 앱의 메뉴에서 **Settings** → **Developer** → **Edit Con
 }
 ```
 
-> 토큰 발급이 처음이라면 [토큰 발급 가이드](docs/setup-guide.md#api-토큰-설정)를 참고하세요.
+> 팀에서 공유하려면 `SLACK_USER_TOKEN` 대신 `SLACK_BOT_TOKEN`(`xoxb-`)을 사용할 수 있습니다. 자세한 내용은 [토큰 발급 가이드](docs/setup-guide.md#api-토큰-설정)를 참고하세요.
 
 **3단계: Claude Desktop 재시작**
 


### PR DESCRIPTION
## Summary
- README 설치 예시를 `SLACK_USER_TOKEN`(사용자 토큰)으로 변경
- setup-guide에서 사용자 토큰을 방식 A(권장), 봇 토큰을 방식 B(팀 공유 시)로 순서 변경
- 비 개발자가 "봇"이라는 개념 없이 바로 시작할 수 있도록 진입 장벽 감소

closes #117

## Test plan
- [x] README 설치 예시가 `SLACK_USER_TOKEN`으로 표시됨
- [x] setup-guide 토큰 테이블에서 사용자 토큰이 첫 번째(권장)
- [x] 방식 A = 사용자 토큰(권장), 방식 B = Bot 토큰(팀 공유 시)으로 순서 확인
- [x] 4단계 환경변수 예시, .env 예시 모두 사용자 토큰 기본으로 변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)