### PR TITLE
fix: Claude Desktop MCP 연결 실패 수정 — uvx 절대 경로 사용

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,48 @@ graph LR
 
 ### Claude Desktop 앱 (일반 사용자)
 
-Claude Desktop 앱을 사용하고 있다면 설정 파일에 아래 내용을 추가하면 됩니다.
+Claude Desktop 앱을 사용하고 있다면 아래 순서대로 진행하세요.
 
-**1단계: 설정 파일 열기**
+**1단계: uv 설치 (처음 한 번만)**
 
-Claude Desktop 앱의 메뉴에서 **Settings** → **Developer** → **Edit Config** 를 클릭합니다.
+이 플러그인은 [uv](https://docs.astral.sh/uv/)라는 도구가 필요합니다. 이미 설치했다면 2단계로 넘어가세요.
 
-<!-- TODO: Claude Desktop Settings > Developer > Edit Config 스크린샷 추가 -->
+1. **터미널**을 엽니다 (Spotlight에서 "터미널" 검색, 또는 `응용 프로그램 > 유틸리티 > 터미널`)
+2. 아래 명령어를 복사해서 터미널에 붙여넣고 Enter를 누릅니다:
+   ```
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+3. 설치가 끝나면 터미널을 **닫았다가 다시 엽니다**
+4. 아래 명령어를 붙여넣고 Enter를 누릅니다. 출력된 경로를 **복사**해두세요:
+   ```
+   which uvx
+   ```
+   `/Users/사용자이름/.local/bin/uvx` 같은 경로가 나옵니다. 이 경로를 2단계에서 사용합니다.
 
-**2단계: 설정 붙여넣기**
+> `which uvx`에서 아무것도 나오지 않으면 터미널을 닫고 다시 열어보세요.
+> 그래도 안 되면 `$HOME/.local/bin/uvx` 경로를 직접 사용하세요.
 
-열린 파일에 아래 내용을 복사해서 붙여넣고, `토큰값을-여기에-입력` 부분을 실제 토큰으로 교체합니다:
+**2단계: 설정 파일 열기**
+
+1. Claude Desktop 앱 좌측 상단의 **계정 아이콘**을 클릭합니다
+2. **설정**을 클릭합니다 (단축키: `⌘ + ,`)
+3. 왼쪽 메뉴 하단 **데스크톱 앱** 섹션에서 **개발자**를 클릭합니다
+4. **구성 편집**을 클릭하면 Finder에서 설정 파일(`claude_desktop_config.json`)이 열립니다
+5. 이 파일을 **텍스트 편집기**로 엽니다 (파일을 우클릭 → 다음으로 열기 → 텍스트 편집기)
+
+**3단계: 설정 붙여넣기**
+
+파일의 기존 내용을 **전부 지우고** 아래 내용을 붙여넣습니다.
+두 군데를 수정하세요:
+
+- `여기에-uvx-경로-붙여넣기` → 1단계에서 복사한 uvx 경로로 교체
+- `토큰값을-여기에-입력` → 실제 토큰으로 교체 ([토큰 발급 가이드](docs/setup-guide.md#api-토큰-설정))
 
 ```json
 {
   "mcpServers": {
     "slack-to-notion": {
-      "command": "uvx",
+      "command": "여기에-uvx-경로-붙여넣기",
       "args": ["slack-to-notion-mcp"],
       "env": {
         "SLACK_USER_TOKEN": "xoxp-토큰값을-여기에-입력",
@@ -47,20 +72,34 @@ Claude Desktop 앱의 메뉴에서 **Settings** → **Developer** → **Edit Con
 }
 ```
 
-> 팀에서 공유하려면 `SLACK_USER_TOKEN` 대신 `SLACK_BOT_TOKEN`(`xoxb-`)을 사용할 수 있습니다. 자세한 내용은 [토큰 발급 가이드](docs/setup-guide.md#api-토큰-설정)를 참고하세요.
+예시 (uvx 경로가 `/Users/hong/.local/bin/uvx`인 경우):
 
-**3단계: Claude Desktop 재시작**
+```json
+{
+  "mcpServers": {
+    "slack-to-notion": {
+      "command": "/Users/hong/.local/bin/uvx",
+      "args": ["slack-to-notion-mcp"],
+      "env": {
+        "SLACK_USER_TOKEN": "xoxp-1234-5678-abcd",
+        "NOTION_API_KEY": "secret_abc123",
+        "NOTION_PARENT_PAGE_ID": "https://www.notion.so/My-Page-abc123"
+      }
+    }
+  }
+}
+```
 
-파일을 저장하고 Claude Desktop을 완전히 종료한 뒤 다시 실행합니다.
-입력창 우측 하단에 도구 아이콘이 나타나면 설치 완료입니다.
+> 팀에서 공유하려면 `SLACK_USER_TOKEN` 대신 `SLACK_BOT_TOKEN`(`xoxb-`)을 사용할 수 있습니다.
+> 자세한 내용은 [토큰 발급 가이드](docs/setup-guide.md#api-토큰-설정)를 참고하세요.
 
-<!-- TODO: Claude Desktop 도구 아이콘 표시 스크린샷 추가 -->
+**4단계: Claude Desktop 재시작**
 
-> **uvx가 없다는 에러가 나오나요?** uv를 먼저 설치해야 합니다. 터미널(Spotlight에서 "터미널" 검색)을 열고 아래를 붙여넣으세요:
-> ```
-> curl -LsSf https://astral.sh/uv/install.sh | sh
-> ```
-> 설치 후 Claude Desktop을 재시작하면 됩니다.
+파일을 저장(`⌘ + S`)하고 Claude Desktop을 **완전히 종료**(Dock에서 우클릭 → 종료)한 뒤 다시 실행합니다.
+
+정상 연결 시: 입력창 우측 하단에 도구 아이콘(🔧)이 나타납니다.
+
+> 재시작해도 오류가 나오면 [문제 해결 가이드](docs/troubleshooting.md)를 확인하세요.
 
 ### Claude Code CLI (개발자)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,7 +5,8 @@
 | 증상 | 원인 | 해결 방법 |
 |------|------|-----------|
 | 설치 후 첫 실행에서 플러그인이 인식되지 않음 | Claude Code CLI 캐시 이슈 | `/exit`으로 종료 후 `claude`를 다시 실행 |
-| `uvx: command not found` | uv 미설치 | `brew install uv` 또는 [uv 설치 가이드](https://docs.astral.sh/uv/getting-started/installation/) 참고 |
+| `spawn uvx ENOENT` (Claude Desktop) | Claude Desktop이 uvx 경로를 찾지 못함 | 아래 [Claude Desktop에서 uvx를 찾지 못하는 경우](#claude-desktop에서-uvx를-찾지-못하는-경우) 참고 |
+| `uvx: command not found` (터미널) | uv 미설치 | `curl -LsSf https://astral.sh/uv/install.sh \| sh` 실행 후 터미널 재시작 |
 | `No module named slack_to_notion` | 패키지 설치 안 됨 | `uv cache clean slack-to-notion-mcp && uvx slack-to-notion-mcp@latest --help` |
 | `SLACK_BOT_TOKEN 또는 SLACK_USER_TOKEN 환경변수가 설정되지 않았습니다` | 환경변수 미설정 | [설치 가이드](setup-guide.md#4단계-환경변수-설정) 참고 |
 | `not_in_channel` 에러 (Bot 토큰) | Bot이 채널에 초대되지 않음 | 채널 설정 → Integrations → Add apps에서 Bot 추가 |
@@ -13,6 +14,27 @@
 | `invalid_auth` 에러 | 토큰이 잘못되었거나 만료됨 | [Slack API](https://api.slack.com/apps)에서 토큰 재확인 |
 | `Notion API 키가 올바르지 않습니다` | Notion API Key가 잘못됨 | [Notion Integrations](https://www.notion.so/my-integrations)에서 Secret 재확인 |
 | `Notion 페이지를 찾을 수 없습니다` | Integration이 페이지에 연결되지 않음 | [설치 가이드](setup-guide.md#2단계-notion-api-key-발급)의 "Integration을 Notion 페이지에 연결하기" 참고 |
+
+## Claude Desktop에서 uvx를 찾지 못하는 경우
+
+Claude Desktop은 일반 앱이라 터미널의 PATH 설정(`~/.zshrc` 등)을 읽지 못합니다.
+터미널에서 `uvx`가 정상 동작해도 Claude Desktop에서는 `spawn uvx ENOENT` 오류가 발생할 수 있습니다.
+
+**해결 방법: uvx 절대 경로 사용**
+
+1. 터미널을 열고 아래 명령어를 실행합니다:
+   ```
+   which uvx
+   ```
+2. 출력된 경로(예: `/Users/사용자이름/.local/bin/uvx`)를 복사합니다
+3. `claude_desktop_config.json`에서 `"command"` 값을 절대 경로로 변경합니다:
+   ```json
+   "command": "/Users/사용자이름/.local/bin/uvx"
+   ```
+4. Claude Desktop을 재시작합니다
+
+> `which uvx`에서 아무것도 나오지 않으면 uv가 설치되지 않은 것입니다.
+> `curl -LsSf https://astral.sh/uv/install.sh | sh` 로 설치한 뒤 터미널을 재시작하세요.
 
 ## 제약사항
 


### PR DESCRIPTION
## Summary

- Claude Desktop이 셸 PATH를 상속받지 않아 `spawn uvx ENOENT` 오류 발생하는 문제 수정
- README의 Claude Desktop 설치 가이드를 uvx 절대 경로 기반으로 전면 재작성
- troubleshooting에 `spawn uvx ENOENT` 해결법 추가

## 변경 내용

- **README.md**: uv 설치를 선행 필수 단계로 격상, `which uvx`로 경로 확인 → 절대 경로 사용 안내, Claude Desktop UI 경로를 한국어 기준으로 상세화
- **docs/troubleshooting.md**: Claude Desktop uvx PATH 문제 섹션 추가

## Test plan

- [x] README 가이드 절차가 논리적으로 완결됨 확인
- [x] troubleshooting 앵커 링크 정상 동작 확인
- [ ] 클린 노트북에서 가이드대로 E2E 검증 (머지 후 진행)

> 이 PR은 #119를 자동으로 닫지 않습니다 (Refs #119).
> 클린 환경 E2E 검증 완료 후 이슈를 수동으로 닫습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced setup instructions with explicit terminal commands for uv installation and configuration.
  * Improved MCP server configuration guidance with concrete JSON examples and environment variable instructions.
  * Expanded troubleshooting section with detailed solutions for uvx path issues and token-related errors.
  * Added step-by-step instructions for configuring Claude Desktop integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->