### PR TITLE
fix: 에러 메시지를 환경 중립적으로 변경 — Desktop + CLI 지원

### DIFF
--- a/src/slack_to_notion/mcp_server.py
+++ b/src/slack_to_notion/mcp_server.py
@@ -53,7 +53,8 @@ def _get_slack_client() -> SlackClient:
         if not token:
             raise RuntimeError(
                 "SLACK_BOT_TOKEN 또는 SLACK_USER_TOKEN 환경변수가 설정되지 않았습니다. "
-                ".mcp.json 파일의 env 섹션을 확인하세요."
+                "Claude Desktop: 설정 파일(claude_desktop_config.json)의 env 섹션을 확인하세요. "
+                "Claude Code CLI: claude mcp add 명령의 -e 옵션을 확인하세요."
             )
         # 접두사로 토큰 타입 판별
         token_type = "user" if token.startswith("xoxp-") else "bot"
@@ -70,7 +71,8 @@ def _get_notion_client() -> NotionClient:
         if not api_key:
             raise RuntimeError(
                 "NOTION_API_KEY 환경변수가 설정되지 않았습니다. "
-                ".mcp.json 파일의 env 섹션을 확인하세요."
+                "Claude Desktop: 설정 파일(claude_desktop_config.json)의 env 섹션을 확인하세요. "
+                "Claude Code CLI: claude mcp add 명령의 -e 옵션을 확인하세요."
             )
         _notion_client = NotionClient(api_key)
         logger.info("NotionClient 초기화 완료")

--- a/src/slack_to_notion/notion_client.py
+++ b/src/slack_to_notion/notion_client.py
@@ -166,7 +166,7 @@ class NotionClient:
         """APIResponseError를 사용자 친화적 한글 메시지로 변환."""
         code = error.code
         if code in ("unauthorized", "invalid_api_key"):
-            return "Notion API 키가 올바르지 않습니다. .env 파일의 NOTION_API_KEY를 확인하세요."
+            return "Notion API 키가 올바르지 않습니다. NOTION_API_KEY 값을 확인하세요. 토큰은 ntn_ 또는 secret_로 시작해야 합니다."
         elif code == "object_not_found":
             return "Notion 페이지를 찾을 수 없습니다. Integration이 해당 페이지에 연결되어 있는지 확인하세요."
         elif code == "restricted_resource":

--- a/src/slack_to_notion/slack_client.py
+++ b/src/slack_to_notion/slack_client.py
@@ -214,8 +214,8 @@ class SlackClient:
 
         if error_code in ("invalid_auth", "not_authed"):
             if is_user_token:
-                return "Slack 토큰이 올바르지 않습니다. .env 파일의 SLACK_USER_TOKEN을 확인하세요."
-            return "Slack 토큰이 올바르지 않습니다. .env 파일의 SLACK_BOT_TOKEN을 확인하세요."
+                return "Slack 토큰이 올바르지 않습니다. SLACK_USER_TOKEN 값을 확인하세요. 토큰은 xoxp-로 시작해야 합니다."
+            return "Slack 토큰이 올바르지 않습니다. SLACK_BOT_TOKEN 값을 확인하세요. 토큰은 xoxb-로 시작해야 합니다."
 
         if error_code in ("channel_not_found", "not_in_channel"):
             if is_user_token:


### PR DESCRIPTION
## Summary
- 에러 메시지에서 `.env`, `.mcp.json` 등 특정 환경 파일 참조 제거
- Claude Desktop과 Claude Code CLI 모두에서 유용한 안내로 변경
- 토큰 형식 힌트 추가 (`xoxp-`, `xoxb-`, `ntn_`/`secret_`)

## 변경 파일

| 파일 | Before | After |
|------|--------|-------|
| `mcp_server.py` | `.mcp.json 파일의 env 섹션을 확인하세요` | Desktop: `claude_desktop_config.json` / CLI: `claude mcp add -e` 안내 |
| `slack_client.py` | `.env 파일의 SLACK_*_TOKEN을 확인하세요` | 토큰 변수명 + 형식 힌트 |
| `notion_client.py` | `.env 파일의 NOTION_API_KEY를 확인하세요` | 토큰 변수명 + 형식 힌트 |

## Test plan
- [x] `uv run pytest tests/ -v` — 156 passed

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API configuration error messages with clearer guidance on Slack token setup (xoxb- for bot tokens, xoxp- for user tokens) and Notion token requirements (ntn_ or secret_ prefixes).
  * Enhanced instructions for configuring the integration with Claude Desktop and Claude Code CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->