### PR TITLE
fix: uv tool install 영구 설치가 uvx 버전 갱신 차단 문제 해결

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -31,18 +31,30 @@ claude mcp add slack-to-notion \
 
 ### 업데이트
 
-이미 설치된 경우 동일한 명령으로 업데이트할 수 있습니다:
+**Claude Code CLI:**
 
 ```bash
-# 방법 1: setup.sh (토큰 자동 재사용)
+# 방법 1: setup.sh (토큰 자동 재사용, 권장)
 curl -sL https://raw.githubusercontent.com/dykim-base-project/claude-slack-to-notion/main/scripts/setup.sh | bash
 
-# 방법 2: uvx 직접 실행 (캐시 초기화 후 최신 버전)
-uv cache clean slack-to-notion-mcp && uvx slack-to-notion-mcp@latest --help
+# 방법 2: 수동 (영구 설치 제거 + 캐시 정리)
+uv tool uninstall slack-to-notion-mcp 2>/dev/null; uv cache clean slack-to-notion-mcp --force
 ```
 
 setup.sh는 기존 설치를 감지하면 자동으로 업데이트 모드로 전환됩니다.
 기존 토큰은 자동으로 재사용되므로 토큰을 다시 입력하지 않아도 됩니다.
+
+**Claude Desktop:**
+
+Claude Desktop을 **완전히 종료**한 뒤 터미널에서 아래 명령어를 실행하세요:
+
+```bash
+uv tool uninstall slack-to-notion-mcp 2>/dev/null; uv cache clean slack-to-notion-mcp --force
+```
+
+이후 Claude Desktop을 다시 실행하면 최신 버전이 자동으로 다운로드됩니다.
+
+> `uv tool uninstall`이 핵심입니다. `uv tool install`로 영구 설치된 환경이 있으면 `uvx`가 PyPI 최신 버전을 무시합니다.
 
 ### 설정 확인 및 수정
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,7 +7,8 @@
 | 설치 후 첫 실행에서 플러그인이 인식되지 않음 | Claude Code CLI 캐시 이슈 | `/exit`으로 종료 후 `claude`를 다시 실행 |
 | `spawn uvx ENOENT` (Claude Desktop) | Claude Desktop이 uvx 경로를 찾지 못함 | 아래 [Claude Desktop에서 uvx를 찾지 못하는 경우](#claude-desktop에서-uvx를-찾지-못하는-경우) 참고 |
 | `uvx: command not found` (터미널) | uv 미설치 | `curl -LsSf https://astral.sh/uv/install.sh \| sh` 실행 후 터미널 재시작 |
-| `No module named slack_to_notion` | 패키지 설치 안 됨 | `uv cache clean slack-to-notion-mcp && uvx slack-to-notion-mcp@latest --help` |
+| `No module named slack_to_notion` | 패키지 설치 안 됨 | `uv cache clean slack-to-notion-mcp --force && uvx slack-to-notion-mcp --help` |
+| 업데이트 후에도 구버전이 실행됨 | `uv tool install`로 영구 설치된 환경이 `uvx`를 차단 | 아래 [버전이 올라가지 않는 경우](#버전이-올라가지-않는-경우) 참고 |
 | `SLACK_BOT_TOKEN 또는 SLACK_USER_TOKEN 환경변수가 설정되지 않았습니다` | 환경변수 미설정 | [설치 가이드](setup-guide.md#4단계-환경변수-설정) 참고 |
 | `not_in_channel` 에러 (Bot 토큰) | Bot이 채널에 초대되지 않음 | 채널 설정 → Integrations → Add apps에서 Bot 추가 |
 | `not_in_channel` 에러 (사용자 토큰) | 해당 채널에 참여하지 않음 | Slack에서 채널에 참여한 뒤 다시 시도 |
@@ -35,6 +36,33 @@ Claude Desktop은 일반 앱이라 터미널의 PATH 설정(`~/.zshrc` 등)을 �
 
 > `which uvx`에서 아무것도 나오지 않으면 uv가 설치되지 않은 것입니다.
 > `curl -LsSf https://astral.sh/uv/install.sh | sh` 로 설치한 뒤 터미널을 재시작하세요.
+
+## 버전이 올라가지 않는 경우
+
+`uvx --refresh`를 사용해도 구버전이 계속 실행되는 경우, `uv tool install`로 생성된 영구 설치가 원인입니다.
+
+**확인 방법:**
+
+```
+uv tool list
+```
+
+`slack-to-notion-mcp`가 목록에 있으면 영구 설치가 존재하는 것입니다.
+
+**해결 방법:**
+
+```bash
+# 1. 영구 설치 제거
+uv tool uninstall slack-to-notion-mcp
+
+# 2. 캐시도 정리
+uv cache clean slack-to-notion-mcp --force
+
+# 3. 확인 (최신 버전이 표시되어야 함)
+uvx slack-to-notion-mcp --help
+```
+
+> Claude Desktop 사용자: 위 명령 실행 후 Claude Desktop을 재시작하세요.
 
 ## 제약사항
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-to-notion-mcp"
-version = "0.2.2"
+version = "0.2.3"
 description = "Slack 메시지/스레드를 분석하여 Notion 페이지로 정리하는 MCP 서버"
 requires-python = ">=3.10"
 license = "MIT"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -198,9 +198,14 @@ except:
     print_warn "기존 플러그인 제거 건너뜀 (이미 제거되었거나 접근 불가)"
   fi
 
-  print_step "uvx 캐시 갱신 중..."
+  print_step "기존 환경 정리 중..."
+  # 영구 설치(uv tool install)가 있으면 제거 — uvx 버전 갱신을 차단하는 원인
+  if uv tool list 2>/dev/null | grep -q "slack-to-notion-mcp"; then
+    uv tool uninstall slack-to-notion-mcp 2>/dev/null || true
+    print_ok "기존 영구 설치 제거 완료"
+  fi
   uv cache clean slack-to-notion-mcp --force 2>/dev/null || true
-  print_ok "uvx 캐시 갱신 완료"
+  print_ok "캐시 정리 완료"
 fi
 
 # ============================================================

--- a/src/slack_to_notion/mcp_server.py
+++ b/src/slack_to_notion/mcp_server.py
@@ -58,8 +58,13 @@ def _get_slack_client() -> SlackClient:
             )
         # 접두사로 토큰 타입 판별
         token_type = "user" if token.startswith("xoxp-") else "bot"
+        # 토큰 접두사 로깅 (디버깅용, 값 노출 방지)
+        token_prefix = token[:10] if len(token) > 10 else token[:4]
+        logger.info(
+            "SlackClient 초기화 (token_type=%s, prefix=%s..., len=%d)",
+            token_type, token_prefix, len(token),
+        )
         _slack_client = SlackClient(token, token_type)
-        logger.info("SlackClient 초기화 완료 (token_type=%s)", token_type)
     return _slack_client
 
 
@@ -74,8 +79,9 @@ def _get_notion_client() -> NotionClient:
                 "Claude Desktop: 설정 파일(claude_desktop_config.json)의 env 섹션을 확인하세요. "
                 "Claude Code CLI: claude mcp add 명령의 -e 옵션을 확인하세요."
             )
+        key_prefix = api_key[:10] if len(api_key) > 10 else api_key[:4]
+        logger.info("NotionClient 초기화 (prefix=%s..., len=%d)", key_prefix, len(api_key))
         _notion_client = NotionClient(api_key)
-        logger.info("NotionClient 초기화 완료")
     return _notion_client
 
 
@@ -432,6 +438,15 @@ def list_analysis_history(limit: int = 10) -> str:
         return f"[에러] 히스토리 조회 실패: {e!s}"
 
 
+def _get_package_version() -> str:
+    """패키지 버전을 반환한다."""
+    try:
+        from importlib.metadata import version
+        return version("slack-to-notion-mcp")
+    except Exception:
+        return "unknown"
+
+
 def main():
     """MCP 서버 진입점. uvx 및 python -m 실행 시 호출된다."""
     if "--help" in sys.argv or "-h" in sys.argv:
@@ -448,7 +463,8 @@ def main():
         print("자세한 내용:")
         print("  https://github.com/dykim-base-project/claude-slack-to-notion")
         return
-    logger.info("Slack-to-Notion MCP 서버 시작")
+    pkg_version = _get_package_version()
+    logger.info("Slack-to-Notion MCP 서버 시작 (v%s)", pkg_version)
     mcp.run()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -831,7 +831,7 @@ wheels = [
 
 [[package]]
 name = "slack-to-notion-mcp"
-version = "0.1.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

- `uv tool install`로 생성된 영구 설치가 `uvx`(= `uv tool run`)의 PyPI 최신 버전 확인을 차단하는 근본 원인 해결
- 디버깅용 패키지 버전/토큰 접두사 로깅 추가
- 업데이트 가이드 보완

## 근본 원인

`uvx slack-to-notion-mcp` 실행 시, `/Users/USER/.local/share/uv/tools/slack-to-notion-mcp/`에 영구 설치가 존재하면:
- `--refresh`: PyPI 인덱스 캐시만 갱신 → 영구 설치에 영향 없음
- `--no-cache`: 캐시 우회 → 영구 설치에 영향 없음
- `uv cache clean`: 캐시 삭제 → 영구 설치 별개

**`uv tool uninstall`로 영구 설치를 제거해야만 `uvx`가 PyPI에서 최신 버전을 가져옴**

## 변경 사항

| 파일 | 변경 |
|------|------|
| `mcp_server.py` | 시작 로그에 패키지 버전 표시, 토큰 접두사/길이 디버그 로깅 |
| `setup.sh` | 업데이트 시 `uv tool uninstall` 실행하여 영구 설치 제거 |
| `troubleshooting.md` | "버전이 올라가지 않는 경우" 해결 가이드 추가 |
| `setup-guide.md` | Claude Desktop/CLI별 업데이트 방법 분리 안내 |
| `pyproject.toml` | v0.2.3 |

## Test plan

- [x] 156개 기존 테스트 전체 통과
- [x] `uv tool uninstall` 후 `uvx` 실행 시 0.2.2 정상 반환 확인
- [ ] Claude Desktop에서 v0.2.3 배포 후 버전 로그 확인

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added troubleshooting guide for version update issues with detailed resolution steps.

* **Documentation**
  * Enhanced setup guide with clearer installation and update instructions for Claude Desktop and CLI tools.
  * Expanded troubleshooting documentation with comprehensive remediation procedures.

* **Chores**
  * Bumped version to 0.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->