### PR TITLE
feat: 실시간 활성 사용자 확인 기능 추가

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,6 +11,7 @@ claude-slack-to-notion이 Claude Code에 제공하는 MCP 도구 목록입니다
 | `fetch_messages` | 특정 채널의 메시지 조회 |
 | `fetch_thread` | 특정 스레드의 전체 메시지 조회 |
 | `fetch_threads` | 여러 스레드를 한 번에 수집하고 AI 분석용으로 포맷팅 |
+| `check_active_users` | 워크스페이스에서 현재 활성(온라인) 사용자 조회 |
 | `fetch_channel_info` | 채널 상세 정보 조회 |
 
 ## 분석

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-to-notion-mcp"
-version = "0.2.3"
+version = "0.3.0"
 description = "Slack 메시지/스레드를 분석하여 Notion 페이지로 정리하는 MCP 서버"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/slack_to_notion/mcp_server.py
+++ b/src/slack_to_notion/mcp_server.py
@@ -214,6 +214,27 @@ def fetch_threads(
 
 
 @mcp.tool()
+def check_active_users() -> str:
+    """워크스페이스에서 현재 활성(온라인) 상태인 사용자 목록을 조회한다.
+
+    전체 사용자 중 현재 Slack에 접속하여 활동 중인 사용자만 반환한다.
+
+    Returns:
+        활성 사용자 리스트를 JSON 형식 문자열로 반환
+        [{"id": "U123", "name": "홍길동", "real_name": "홍길동", "presence": "active"}]
+    """
+    try:
+        client = _get_slack_client()
+        active_users = client.get_active_users()
+        return json.dumps(active_users, ensure_ascii=False)
+    except SlackClientError as e:
+        return f"[에러] {e.message}"
+    except Exception as e:
+        logger.exception("예상치 못한 에러 발생")
+        return f"[에러] 활성 사용자 조회 실패: {e!s}"
+
+
+@mcp.tool()
 def fetch_channel_info(channel_id: str) -> str:
     """Slack 채널의 상세 정보를 조회한다.
 


### PR DESCRIPTION
## Summary
- 워크스페이스에서 현재 활성(온라인) 상태인 사용자를 조회하는 `check_active_users` MCP 도구 추가
- `users.list` → `users.getPresence` 조합으로 활성 사용자 필터링
- 추가 Slack 스코프 불필요 (기존 `users:read`로 충분)
- 테스트 7건 추가 (총 36건 통과)

## Test plan
- [x] 단위 테스트 36건 전체 통과
- [ ] E2E: `현재 온라인인 사용자 알려줘` 요청 시 활성 사용자 목록 반환 확인

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capability to identify and list currently active (online) users in your Slack workspace

* **Documentation**
  * Updated tools documentation to include the new user activity tool

* **Tests**
  * Added comprehensive tests for user listing, presence detection, and active-user filtering

* **Chores**
  * Bumped project version to 0.3.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->