### PR TITLE
chore: v0.3.1 버전업 및 버전 관리 지침 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,3 +160,19 @@ fetch → rebase → (충돌 시 해결) → force push → merge → 다음 PR
 
 - `2>&1 || true` 패턴으로 Stop hook 중단 방지
 - 충돌 없는 PR은 연속 처리, 충돌 발생 시에만 수동 개입
+
+### 버전 관리 (PyPI 배포)
+
+이 레포는 MCP 서버 패키지(`slack-to-notion-mcp`)를 PyPI로 배포한다. 버전 파이프라인:
+
+```
+pyproject.toml version 변경 → auto-tag.yml (태그 생성) → pypi-publish.yml (PyPI 배포)
+```
+
+**규칙: `src/` 하위 파일을 변경하는 PR에는 반드시 `pyproject.toml`의 patch 버전을 올린다.**
+
+- `feat`: minor 또는 patch 증가 (기능 규모에 따라 판단)
+- `fix`, `refactor`, `docs`(코드 내 docstring 등): patch 증가
+- `docs`(README 등 코드 외 문서만), `chore`: 버전 변경 불필요
+
+버전을 올리지 않으면 auto-tag가 트리거되지 않아 PyPI에 배포되지 않고, Claude Desktop 사용자에게 변경사항이 전달되지 않는다.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-to-notion-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Slack 메시지/스레드를 분석하여 Notion 페이지로 정리하는 MCP 서버"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## Summary

- PR #134 멘션 치환 기능이 PyPI v0.3.0에 포함되지 않아 Claude Desktop에서 반영되지 않던 문제 해결
- `pyproject.toml` 버전을 `0.3.0` → `0.3.1`로 증가
- `CLAUDE.md`에 `src/` 변경 시 patch 버전 필수 규칙 추가 (재발 방지)

## Test plan

- [x] 머지 후 `auto-tag.yml` → `pypi-publish.yml` 파이프라인으로 v0.3.1 자동 배포 확인
- [x] Claude Desktop 재시작 후 멘션 치환 기능 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version incremented to 0.3.1 for this maintenance release

* **Documentation**
  * Established comprehensive versioning and PyPI deployment process documentation. Details the automated version tagging and publishing pipeline workflow. Provides specific patch increment rules for source code modifications with clear guidance on handling features, fixes, refactoring, documentation updates, and maintenance-only changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->