### PR TITLE
feat: DM 목록 조회 도구 추가

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -121,6 +121,12 @@ Slack 채널의 메시지를 읽어오려면 Slack App을 만들고 토큰을 �
 | `channels:read` | 채널 목록을 조회합니다 |
 | `groups:history` | 비공개 채널의 메시지를 읽습니다 |
 | `users:read` | 메시지 작성자의 이름을 확인합니다 |
+| `im:read` | 1:1 DM 목록을 조회합니다 (선택) |
+| `im:history` | 1:1 DM 메시지를 읽습니다 (선택) |
+| `mpim:read` | 그룹 DM 목록을 조회합니다 (선택) |
+| `mpim:history` | 그룹 DM 메시지를 읽습니다 (선택) |
+
+> **참고**: DM 스코프는 선택 사항입니다. 추가하지 않아도 채널 기능은 정상 동작합니다.
 
 6. 페이지 상단으로 스크롤하여 **"Install to Workspace"** 클릭 → **"허용"** 클릭
 7. **"User OAuth Token"** 이 표시됩니다. 복사 버튼을 눌러 토큰을 복사합니다. (`xoxp-`로 시작하는 문자열)
@@ -146,6 +152,10 @@ Slack 채널의 메시지를 읽어오려면 Slack App을 만들고 토큰을 �
 | `channels:read` | 채널 목록을 조회합니다 |
 | `groups:history` | 비공개 채널의 메시지를 읽습니다 |
 | `users:read` | 메시지 작성자의 이름을 확인합니다 |
+| `im:read` | 1:1 DM 목록을 조회합니다 (선택) |
+| `im:history` | 1:1 DM 메시지를 읽습니다 (선택) |
+| `mpim:read` | 그룹 DM 목록을 조회합니다 (선택) |
+| `mpim:history` | 그룹 DM 메시지를 읽습니다 (선택) |
 
 > 비공개 채널 목록도 조회하려면 `groups:read` 스코프를 추가하세요. 없어도 공개 채널은 정상 동작합니다.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,6 +10,7 @@
 | `No module named slack_to_notion` | 패키지 설치 안 됨 | `uv cache clean slack-to-notion-mcp --force && uvx slack-to-notion-mcp --help` |
 | 업데이트 후에도 구버전이 실행됨 | `uv tool install`로 영구 설치된 환경이 `uvx`를 차단 | 아래 [버전이 올라가지 않는 경우](#버전이-올라가지-않는-경우) 참고 |
 | `SLACK_BOT_TOKEN 또는 SLACK_USER_TOKEN 환경변수가 설정되지 않았습니다` | 환경변수 미설정 | [설치 가이드](setup-guide.md#4단계-환경변수-설정) 참고 |
+| `DM 조회에 필요한 권한이 없습니다` | DM 스코프 미설정 | Slack App 설정에서 `im:read`, `im:history` 스코프 추가 ([설치 가이드](setup-guide.md) 참고) |
 | `not_in_channel` 에러 (Bot 토큰) | Bot이 채널에 초대되지 않음 | 채널 설정 → Integrations → Add apps에서 Bot 추가 |
 | `not_in_channel` 에러 (사용자 토큰) | 해당 채널에 참여하지 않음 | Slack에서 채널에 참여한 뒤 다시 시도 |
 | `invalid_auth` 에러 | 토큰이 잘못되었거나 만료됨 | [Slack API](https://api.slack.com/apps)에서 토큰 재확인 |
@@ -67,6 +68,6 @@ uvx slack-to-notion-mcp --help
 ## 제약사항
 
 - **API 토큰 관리**: Slack API 토큰, Notion API 키는 환경변수로 관리 (Git 추적 금지)
-- **개인 메시지(DM) 제외**: 보안상 개인 DM 수집 지원하지 않음
+- **개인 메시지(DM)**: `im:read`, `im:history` 스코프 추가 필요 ([설치 가이드](setup-guide.md) 참고)
 - **API Rate Limit**: Slack/Notion API Rate Limit 고려 필요 (과도한 요청 시 제한 발생 가능)
 - **채널 접근**: Bot 토큰 사용 시 채널에 앱 초대 필요, 사용자 토큰 사용 시 본인이 참여한 채널만 접근 가능

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-to-notion-mcp"
-version = "0.3.1"
+version = "0.3.2"
 description = "Slack 메시지/스레드를 분석하여 Notion 페이지로 정리하는 MCP 서버"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/slack_to_notion/mcp_server.py
+++ b/src/slack_to_notion/mcp_server.py
@@ -110,6 +110,28 @@ def list_channels() -> str:
 
 
 @mcp.tool()
+def list_dms() -> str:
+    """Slack DM(다이렉트 메시지) 목록을 조회한다.
+
+    1:1 DM과 그룹 DM을 조회한다.
+    반환된 id는 fetch_messages, fetch_thread 등에 그대로 사용 가능하다.
+
+    Returns:
+        DM 정보 리스트를 JSON 형식 문자열로 반환
+        [{"id": "D123", "name": "DM: 김동영", "is_dm": true, "is_group_dm": false}]
+    """
+    try:
+        client = _get_slack_client()
+        dms = client.list_dms()
+        return json.dumps(dms, ensure_ascii=False)
+    except SlackClientError as e:
+        return f"[에러] {e.message}"
+    except Exception as e:
+        logger.exception("예상치 못한 에러 발생")
+        return f"[에러] DM 목록 조회 실패: {e!s}"
+
+
+@mcp.tool()
 def fetch_messages(
     channel_id: str,
     limit: int = 100,

--- a/src/slack_to_notion/slack_client.py
+++ b/src/slack_to_notion/slack_client.py
@@ -81,6 +81,93 @@ class SlackClient:
         except SlackApiError as e:
             raise SlackClientError(self._format_error_message(e)) from e
 
+    def list_dms(self) -> list[dict]:
+        """DM(다이렉트 메시지) 목록 조회.
+
+        1:1 DM과 그룹 DM을 조회한다.
+        반환된 id는 fetch_messages, fetch_thread 등에 그대로 사용 가능하다.
+
+        Returns:
+            DM 정보 리스트 [{"id", "name", "is_dm": True, "is_group_dm": bool}]
+
+        Raises:
+            SlackClientError: API 호출 실패 시
+        """
+        try:
+            dms: list[dict] = []
+            cursor = None
+            types = "im,mpim"
+
+            try:
+                self.client.conversations_list(types=types, limit=1)
+            except SlackApiError as e:
+                if e.response.get("error") == "missing_scope":
+                    # mpim 스코프 없으면 im만 시도
+                    try:
+                        self.client.conversations_list(types="im", limit=1)
+                        types = "im"
+                    except SlackApiError as e2:
+                        if e2.response.get("error") == "missing_scope":
+                            raise SlackClientError(
+                                "DM 조회에 필요한 권한이 없습니다. "
+                                "Slack App 설정에서 im:read 스코프를 추가하세요."
+                            ) from e2
+                        raise
+                else:
+                    raise
+
+            while True:
+                response = self.client.conversations_list(
+                    types=types,
+                    cursor=cursor,
+                    limit=200,
+                )
+
+                for conv in response["channels"]:
+                    is_mpim = conv.get("is_mpim", False)
+                    if is_mpim:
+                        name = self._format_group_dm_name(conv.get("name", ""))
+                    else:
+                        user_id = conv.get("user", "")
+                        if user_id:
+                            user_name = self.get_user_name(user_id)
+                            name = f"DM: {user_name}"
+                        else:
+                            name = f"DM: {conv.get('id', 'unknown')}"
+
+                    dms.append({
+                        "id": conv["id"],
+                        "name": name,
+                        "is_dm": True,
+                        "is_group_dm": is_mpim,
+                    })
+
+                cursor = response.get("response_metadata", {}).get("next_cursor")
+                if not cursor:
+                    break
+
+            return dms
+
+        except SlackApiError as e:
+            raise SlackClientError(self._format_error_message(e)) from e
+
+    def _format_group_dm_name(self, raw_name: str) -> str:
+        """그룹 DM 이름을 포맷팅한다.
+
+        mpdm-alice--bob--charlie-1 → "Group DM: alice, bob, charlie"
+
+        Args:
+            raw_name: Slack 그룹 DM 원본 이름
+
+        Returns:
+            포맷팅된 이름
+        """
+        match = re.match(r"^mpdm-(.+)-\d+$", raw_name)
+        if match:
+            members = match.group(1).split("--")
+            return f"Group DM: {', '.join(members)}"
+        return f"Group DM: {raw_name}"
+
     def fetch_channel_messages(
         self,
         channel_id: str,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -60,6 +60,65 @@ class TestCreateNotionPage:
             assert "에러" in result
 
 
+class TestListDMs:
+    """list_dms 도구 테스트."""
+
+    def test_list_dms_success(self):
+        """JSON 반환, is_dm=True 확인."""
+        import json
+        env = {"SLACK_BOT_TOKEN": "xoxb-fake"}
+        with patch.dict("os.environ", env, clear=False), \
+             patch("slack_to_notion.mcp_server._slack_client", None), \
+             patch("slack_to_notion.slack_client.WebClient") as mock_cls:
+            mock_api = mock_cls.return_value
+            mock_api.conversations_list.return_value = {
+                "channels": [
+                    {"id": "D001", "user": "U001", "is_mpim": False},
+                ],
+                "response_metadata": {"next_cursor": ""},
+            }
+            mock_api.users_info.return_value = {
+                "user": {"profile": {"display_name": "김동영", "real_name": ""}}
+            }
+
+            from slack_to_notion.mcp_server import list_dms
+            result = list_dms()
+            parsed = json.loads(result)
+            assert len(parsed) == 1
+            assert parsed[0]["is_dm"] is True
+            assert parsed[0]["name"] == "DM: 김동영"
+
+    def test_list_dms_slack_client_error(self):
+        """SlackClientError 발생 시 [에러] 반환."""
+        env = {"SLACK_BOT_TOKEN": "xoxb-fake"}
+        with patch.dict("os.environ", env, clear=False), \
+             patch("slack_to_notion.mcp_server._slack_client", None), \
+             patch("slack_to_notion.slack_client.WebClient") as mock_cls:
+            from slack_sdk.errors import SlackApiError
+            error_response = MagicMock()
+            error_response.get.side_effect = lambda key, default="": "invalid_auth" if key == "error" else default
+            mock_cls.return_value.conversations_list.side_effect = SlackApiError(
+                message="err", response=error_response
+            )
+
+            from slack_to_notion.mcp_server import list_dms
+            result = list_dms()
+            assert "[에러]" in result
+
+    def test_list_dms_unexpected_exception(self):
+        """예상치 못한 예외 발생 시 [에러] 반환."""
+        env = {"SLACK_BOT_TOKEN": "xoxb-fake"}
+        with patch.dict("os.environ", env, clear=False), \
+             patch("slack_to_notion.mcp_server._slack_client", None), \
+             patch("slack_to_notion.slack_client.WebClient") as mock_cls:
+            mock_cls.return_value.conversations_list.side_effect = RuntimeError("네트워크 오류")
+
+            from slack_to_notion.mcp_server import list_dms
+            result = list_dms()
+            assert "[에러]" in result
+            assert "DM 목록 조회 실패" in result
+
+
 class TestFetchThreads:
     """fetch_threads 도구 테스트."""
 

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -119,6 +119,131 @@ class TestSlackClientListChannels:
         assert channels[1]["name"] == "ch2"
 
 
+class TestSlackClientListDMs:
+    """DM 목록 조회 테스트."""
+
+    def setup_method(self):
+        with patch("slack_to_notion.slack_client.WebClient"):
+            self.client = SlackClient("xoxb-fake-token")
+            self.mock_api = self.client.client
+
+    def test_list_dms_success(self):
+        """im + mpim 모두 정상 반환, 이름 포맷 확인."""
+        self.mock_api.conversations_list.return_value = {
+            "channels": [
+                {"id": "D001", "user": "U001", "is_mpim": False},
+                {"id": "G001", "name": "mpdm-alice--bob-1", "is_mpim": True},
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+        self.mock_api.users_info.return_value = {
+            "user": {"profile": {"display_name": "김동영", "real_name": ""}}
+        }
+
+        dms = self.client.list_dms()
+        assert len(dms) == 2
+        assert dms[0]["id"] == "D001"
+        assert dms[0]["name"] == "DM: 김동영"
+        assert dms[0]["is_dm"] is True
+        assert dms[0]["is_group_dm"] is False
+        assert dms[1]["id"] == "G001"
+        assert dms[1]["name"] == "Group DM: alice, bob"
+        assert dms[1]["is_group_dm"] is True
+
+    def test_list_dms_im_only_fallback(self):
+        """im,mpim 실패 → im only 폴백."""
+        call_count = 0
+
+        def side_effect(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            types = kwargs.get("types", "")
+            limit = kwargs.get("limit", 200)
+            if call_count == 1 and types == "im,mpim" and limit == 1:
+                raise _make_slack_error("missing_scope")
+            if call_count == 2 and types == "im" and limit == 1:
+                return {"channels": [], "response_metadata": {"next_cursor": ""}}
+            return {
+                "channels": [
+                    {"id": "D001", "user": "U001", "is_mpim": False},
+                ],
+                "response_metadata": {"next_cursor": ""},
+            }
+
+        self.mock_api.conversations_list.side_effect = side_effect
+        self.mock_api.users_info.return_value = {
+            "user": {"profile": {"display_name": "테스트", "real_name": ""}}
+        }
+
+        dms = self.client.list_dms()
+        assert len(dms) == 1
+        # 세 번째 호출(실제 목록 조회)에서 im만 사용 확인
+        third_call_kwargs = self.mock_api.conversations_list.call_args_list[2][1]
+        assert third_call_kwargs["types"] == "im"
+
+    def test_list_dms_no_scope_raises(self):
+        """모든 스코프 없음 → SlackClientError."""
+        self.mock_api.conversations_list.side_effect = _make_slack_error("missing_scope")
+
+        with pytest.raises(SlackClientError) as exc_info:
+            self.client.list_dms()
+        assert "im:read" in exc_info.value.message
+
+    def test_list_dms_pagination(self):
+        """페이지네이션 커서 동작."""
+        self.mock_api.conversations_list.side_effect = [
+            # scope 확인 호출
+            {"channels": [], "response_metadata": {"next_cursor": ""}},
+            # 첫 페이지
+            {
+                "channels": [{"id": "D001", "user": "U001", "is_mpim": False}],
+                "response_metadata": {"next_cursor": "cursor_abc"},
+            },
+            # 두 번째 페이지
+            {
+                "channels": [{"id": "D002", "user": "U002", "is_mpim": False}],
+                "response_metadata": {"next_cursor": ""},
+            },
+        ]
+        self.mock_api.users_info.return_value = {
+            "user": {"profile": {"display_name": "유저", "real_name": ""}}
+        }
+
+        dms = self.client.list_dms()
+        assert len(dms) == 2
+        assert dms[0]["id"] == "D001"
+        assert dms[1]["id"] == "D002"
+
+    def test_list_dms_user_name_resolved(self):
+        """1:1 DM에서 get_user_name 호출 확인."""
+        self.mock_api.conversations_list.return_value = {
+            "channels": [
+                {"id": "D001", "user": "U001", "is_mpim": False},
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+        self.mock_api.users_info.return_value = {
+            "user": {"profile": {"display_name": "홍길동", "real_name": ""}}
+        }
+
+        dms = self.client.list_dms()
+        assert dms[0]["name"] == "DM: 홍길동"
+        self.mock_api.users_info.assert_called_once_with(user="U001")
+
+    def test_list_dms_group_dm_name_formatted(self):
+        """mpdm-a--b--1 → 'Group DM: a, b'."""
+        self.mock_api.conversations_list.return_value = {
+            "channels": [
+                {"id": "G001", "name": "mpdm-alice--bob--charlie-1", "is_mpim": True},
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+        dms = self.client.list_dms()
+        assert dms[0]["name"] == "Group DM: alice, bob, charlie"
+        assert dms[0]["is_group_dm"] is True
+
+
 class TestSlackClientFetchMessages:
     """메시지 조회 테스트."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -831,7 +831,7 @@ wheels = [
 
 [[package]]
 name = "slack-to-notion-mcp"
-version = "0.3.0"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- `list_dms` MCP 도구를 추가하여 1:1 DM 및 그룹 DM 채널 ID를 발견할 수 있도록 함
- 반환된 ID는 기존 `fetch_messages`, `fetch_thread` 등에 그대로 사용 가능
- 설치 가이드 및 troubleshooting 문서에 DM 스코프 안내 추가
- v0.3.2 버전 범프

## Changes
- `SlackClient.list_dms()`: `im,mpim` → `im` only 스코프 폴백, 페이지네이션 지원
- `list_dms` MCP 도구: 기존 `list_channels` 패턴과 동일한 에러 처리
- 테스트 9건 추가 (SlackClient 6건 + MCP 서버 3건)
- 문서: DM 스코프 안내, 제약사항 문구 수정, 에러 항목 추가

## Test plan
- [x] `pytest tests/` 전체 180건 통과
- [x] `ruff check src/ tests/` 신규 린트 이슈 0건
- [ ] PyPI 배포 후 `uvx slack-to-notion-mcp --help` 정상 동작 확인

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Direct Messages (DMs), including both 1:1 and group conversations.

* **Documentation**
  * Updated setup guide with Direct Message permission scopes and optional DM functionality information.
  * Enhanced troubleshooting guide with steps for Direct Message permission issues and Notion API key/page errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->